### PR TITLE
Always use the latest version of an action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,11 +14,11 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v4.5.0
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10.x"
 
-      - uses: actions/checkout@v3.4.0
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 
@@ -33,7 +33,7 @@ jobs:
       - name: build keymap
         run: make moonlander:mcoding
 
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v3
         with:
           name: moonlander_mcoding.bin
           path: .build/moonlander_mcoding.bin

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sync main with upstream latest
 
     steps:
-      - uses: actions/checkout@v3.4.0
+      - uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
           git merge FETCH_HEAD
 
       - name: open pull request
-        uses: peter-evans/create-pull-request@v4.2.4
+        uses: peter-evans/create-pull-request@v4
         id: cpr
         with:
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Noticed that the majority of pull requests are unnecessary dependabot notifications.
If you do not specify the full version number and just define the major, it always use the latest version of the action.